### PR TITLE
Treat an empty list as an empty table

### DIFF
--- a/lib/table/reader/enumerable.ex
+++ b/lib/table/reader/enumerable.ex
@@ -32,13 +32,20 @@ defmodule Table.Reader.Enumerable do
   """
   @spec init_rows(Enumerable.t()) :: Table.Reader.row_reader() | :none
   def init_rows(enum) do
-    with {:ok, head} <- Enum.fetch(enum, 0),
-         {:ok, columns} <- columns_for(head) do
-      meta = %{columns: columns}
-      enum = Stream.map(enum, &record_values(&1, columns))
-      {:rows, meta, enum}
-    else
-      _ -> :none
+    case Enum.fetch(enum, 0) do
+      {:ok, head} ->
+        case columns_for(head) do
+          {:ok, columns} ->
+            meta = %{columns: columns}
+            enum = Stream.map(enum, &record_values(&1, columns))
+            {:rows, meta, enum}
+
+          :error ->
+            :none
+        end
+
+      :error ->
+        {:rows, %{columns: []}, []}
     end
   end
 

--- a/test/table/reader_test.exs
+++ b/test/table/reader_test.exs
@@ -3,7 +3,6 @@ defmodule Table.ReaderTest do
 
   describe "list init/1" do
     test "returns :none for non-tabular lists" do
-      assert Table.Reader.init([]) == :none
       assert Table.Reader.init([1, 2, 3]) == :none
 
       assert Table.Reader.init([[]]) == :none
@@ -13,6 +12,13 @@ defmodule Table.ReaderTest do
       assert Table.Reader.init([{"a", [1, 2]}, {"b", 2}]) == :none
 
       assert Table.Reader.init([%URI{}]) == :none
+    end
+
+    test "empty list" do
+      data = []
+
+      assert {:rows, %{columns: []}, enum} = Table.Reader.init(data)
+      assert Enum.to_list(enum) == []
     end
 
     test "list of key-vals" do

--- a/test/table_test.exs
+++ b/test/table_test.exs
@@ -15,8 +15,8 @@ defmodule TableTest do
 
   describe "to_rows/1" do
     test "raises given invalid tabular data" do
-      assert_raise ArgumentError, "expected valid tabular data, but got: []", fn ->
-        Table.to_rows([])
+      assert_raise ArgumentError, "expected valid tabular data, but got: [1]", fn ->
+        Table.to_rows([1])
       end
     end
 
@@ -51,8 +51,8 @@ defmodule TableTest do
 
   describe "to_columns/1" do
     test "raises given invalid tabular data" do
-      assert_raise ArgumentError, "expected valid tabular data, but got: []", fn ->
-        Table.to_columns([])
+      assert_raise ArgumentError, "expected valid tabular data, but got: [1]", fn ->
+        Table.to_columns([1])
       end
     end
 


### PR DESCRIPTION
In the column format, empty data would look like `%{x: [], y: []}`, however for rows it would be just `[]`. If the data is generated dynamically `[]` is a valid edge case, so it's probably better to treat it as empty rows, rather than raise.