### PR TITLE
Extend validations for tabular list to enforce the same columns

### DIFF
--- a/lib/table/reader/enumerable.ex
+++ b/lib/table/reader/enumerable.ex
@@ -75,18 +75,20 @@ defmodule Table.Reader.Enumerable do
   end
 
   defp record_values(record, columns, head_record) when is_map(record) do
-    {values, remaining_record} =
-      Enum.map_reduce(columns, record, fn column, remaining_record ->
-        Map.pop_lazy(remaining_record, column, fn ->
-          raise "map records must have the same columns, missing column #{inspect(column)} in #{inspect(record)}"
-        end)
-      end)
-
-    if remaining_record != %{} do
-      raise "map records must have the same columns, missing column(s) #{inspect(Map.keys(remaining_record))} in #{inspect(head_record)}"
-    else
-      values
+    if map_size(record) > map_size(head_record) do
+      missing_columns = Map.keys(record) -- columns
+      raise "map records must have the same columns, missing column(s) #{inspect(missing_columns)} in #{inspect(head_record)}"
     end
+
+    Enum.map(columns, fn column ->
+      case record do
+        %{^column => value} ->
+          value
+
+        _ ->
+          raise "map records must have the same columns, missing column #{inspect(column)} in #{inspect(record)}"
+      end
+    end)
   end
 
   defp record_values(record, _columns, _head_record) do

--- a/lib/table/reader/enumerable.ex
+++ b/lib/table/reader/enumerable.ex
@@ -77,12 +77,9 @@ defmodule Table.Reader.Enumerable do
   defp record_values(record, columns, head_record) when is_map(record) do
     {values, remaining_record} =
       Enum.map_reduce(columns, record, fn column, remaining_record ->
-        try do
-          Map.pop!(remaining_record, column)
-        rescue
-          KeyError ->
-            raise "map records must have the same columns, missing column #{inspect(column)} in #{inspect(record)}"
-        end
+        Map.pop_lazy(remaining_record, column, fn ->
+          raise "map records must have the same columns, missing column #{inspect(column)} in #{inspect(record)}"
+        end)
       end)
 
     if remaining_record != %{} do

--- a/lib/table/reader/enumerable.ex
+++ b/lib/table/reader/enumerable.ex
@@ -77,6 +77,7 @@ defmodule Table.Reader.Enumerable do
   defp record_values(record, columns, head_record) when is_map(record) do
     if map_size(record) > map_size(head_record) do
       missing_columns = Map.keys(record) -- columns
+
       raise "map records must have the same columns, missing column(s) #{inspect(missing_columns)} in #{inspect(head_record)}"
     end
 

--- a/lib/table/reader/enumerable.ex
+++ b/lib/table/reader/enumerable.ex
@@ -92,7 +92,7 @@ defmodule Table.Reader.Enumerable do
     end
   end
 
-  defp record_values(record, _head_record, _columns) do
+  defp record_values(record, _columns, _head_record) do
     raise "invalid table record: #{inspect(record)}"
   end
 

--- a/test/table/reader_test.exs
+++ b/test/table/reader_test.exs
@@ -74,6 +74,7 @@ defmodule Table.ReaderTest do
     end
 
     test "enumerating rows raises on missing map element" do
+      # First row has more columns than later rows
       assert {:rows, %{}, enum} =
                Table.Reader.init([
                  %{"x" => 1, "y" => 1},
@@ -82,6 +83,20 @@ defmodule Table.ReaderTest do
 
       assert_raise RuntimeError,
                    ~s/map records must have the same columns, missing column "y" in %{"x" => 2}/,
+                   fn ->
+                     Enum.to_list(enum)
+                   end
+
+      # Later row has more columns than first row
+      assert {:rows, %{}, enum} =
+               Table.Reader.init([
+                 %{"x" => 2},
+                 %{"x" => 1, "y" => 1}
+               ])
+
+
+      assert_raise RuntimeError,
+                   ~s/map records must have the same columns, missing column(s) ["y"] in %{"x" => 2}/,
                    fn ->
                      Enum.to_list(enum)
                    end
@@ -111,6 +126,35 @@ defmodule Table.ReaderTest do
       assert_raise RuntimeError, ~s/expected a key-value pair, but got: 2/, fn ->
         Enum.to_list(enum)
       end
+    end
+
+    test "enumerating rows raises on missing keyval element" do
+      # First row has more columns than later rows
+      assert {:rows, %{}, enum} =
+               Table.Reader.init([
+                 [{"x", 1}, {"y", 1}],
+                 [{"x", 2}]
+               ])
+
+      assert_raise RuntimeError,
+                   ~s/key-value records must have the same columns, missing "y"/,
+                   fn ->
+                     Enum.to_list(enum)
+                   end
+
+      # Later row has more columns than first row
+      assert {:rows, %{}, enum} =
+               Table.Reader.init([
+                 [{"x", 2}],
+                 [{"x", 1}, {"y", 1}]
+               ])
+
+
+      assert_raise RuntimeError,
+                   ~s/key-value records must have the same columns, missing "y"/,
+                   fn ->
+                     Enum.to_list(enum)
+                   end
     end
   end
 

--- a/test/table/reader_test.exs
+++ b/test/table/reader_test.exs
@@ -94,7 +94,6 @@ defmodule Table.ReaderTest do
                  %{"x" => 1, "y" => 1}
                ])
 
-
       assert_raise RuntimeError,
                    ~s/map records must have the same columns, missing column(s) ["y"] in %{"x" => 2}/,
                    fn ->
@@ -148,7 +147,6 @@ defmodule Table.ReaderTest do
                  [{"x", 2}],
                  [{"x", 1}, {"y", 1}]
                ])
-
 
       assert_raise RuntimeError,
                    ~s/key-value records must have the same columns, missing "y"/,


### PR DESCRIPTION
This will validate that the by row data structures have the same columns.

I wanted to do it for the by column data structures as well but I think this needs to modify the zipping functions to signal when there are some leftovers. Either that or there needs to be the ability to `map_reduce` over the columns so you can calculate the lengths when the table is being enumerated. 